### PR TITLE
fix: adds permission to token.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: read
     steps:
       - name: Checkout
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
job was failing because I did not include the right permissions in the previous PR.