### PR TITLE
chore(ci): restrict ci workflow permissions to only read contents

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/openfga-envoy/security/code-scanning/1](https://github.com/openfga/openfga-envoy/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci.yaml`. This block should be placed at the top level (before `jobs:`) to apply to all jobs in the workflow, unless a job requires different permissions. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. This is sufficient for most CI workflows that only need to check out code and run tests/builds. If any steps require additional permissions (e.g., pushing to GHCR, creating releases, or writing to pull requests), those permissions should be added as needed. In this case, since the `docker/login-action` uses the `GITHUB_TOKEN` for authentication to GHCR, but the `push` option in `docker/build-push-action` is set to `false`, no write permissions are needed for contents or packages.

Add the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
